### PR TITLE
fix(getmarbletokenvalue): Check for `undefined` values for given token

### DIFF
--- a/spec/marbles/parseObservableMarble-spec.ts
+++ b/spec/marbles/parseObservableMarble-spec.ts
@@ -27,6 +27,15 @@ describe('parseObservableMarble', () => {
     expect(messages).to.deep.equal(expected);
   });
 
+  it('should correctly parse falsy timeframe value', () => {
+    const marble = '--a-b-c-d';
+
+    const messages = parseObservableMarble(marble, { a: null, b: false, c: 0, d: undefined });
+    const expected = [next(2, null), next(4, false), next(6, 0), next(8, 'd')];
+
+    expect(messages).to.deep.equal(expected);
+  });
+
   it('should parse timeframe with maxFrame', () => {
     const marble = '--a------b--|';
 

--- a/src/marbles/tokenParseReducer.ts
+++ b/src/marbles/tokenParseReducer.ts
@@ -58,7 +58,7 @@ const getMarbleTokenValue = <T>(
   value: { [key: string]: T } | null,
   materializeInnerObservables: boolean
 ) => {
-  const customValue = value && value[token] ? value[token] : token;
+  const customValue = value && typeof value[token] !== 'undefined' ? value[token] : token;
 
   return materializeInnerObservables && customValue instanceof ColdObservable ? customValue.messages : customValue;
 };


### PR DESCRIPTION
Currently passing in "falsy" values like 0, null, false etc... get ignored by the getMarbleTokenValue function and incorrectly defaults to using the token. This PR fixes that by testing explicitly for undefined values before passing the `token` through. 