### PR TITLE
fix(flush): fix hot observable flush order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="0.0.9"></a>
+## [0.0.9](https://github.com/kwonoj/rx-sandbox/compare/v0.0.8...v0.0.9) (2017-12-10)
+
+
+### Bug Fixes
+
+* **flush:** fix hot observable flush order ([c10f1f7](https://github.com/kwonoj/rx-sandbox/commit/c10f1f7))
+
+
+
 <a name="0.0.8"></a>
 ## [0.0.8](https://github.com/kwonoj/rx-sandbox/compare/v0.0.7...v0.0.8) (2017-09-29)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,50 +1,142 @@
 {
   "name": "rx-sandbox",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@commitlint/cli": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-3.2.0.tgz",
-      "integrity": "sha1-vokC8vqFn5Npek4gQwXWtHZICTE=",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-5.2.5.tgz",
+      "integrity": "sha512-UoWLCBuLHpZ6yMq1WUQhOD4YGAx3vakxe98kAiv5ekKCWN2PNJpXAyjyYjqS5P4IMKE0fU37FL1f9LqjsiS5+w==",
       "dev": true,
       "requires": {
-        "@commitlint/core": "3.2.0",
+        "@commitlint/core": "5.2.5",
         "babel-polyfill": "6.26.0",
-        "chalk": "2.1.0",
+        "chalk": "2.3.0",
         "get-stdin": "5.0.1",
         "lodash": "4.17.4",
         "meow": "3.7.0"
+      },
+      "dependencies": {
+        "@commitlint/core": {
+          "version": "5.2.5",
+          "resolved": "https://registry.npmjs.org/@commitlint/core/-/core-5.2.5.tgz",
+          "integrity": "sha512-YWyxMQT8x2VJ9xkXLYbruq272A9TfjLGZTClNl/C4EX2o0bdBce6Kk/2PdyPWpA2++1bTZ0T4zUAE1wqh1Y75g==",
+          "dev": true,
+          "requires": {
+            "@marionebl/sander": "0.6.1",
+            "babel-runtime": "6.26.0",
+            "chalk": "2.3.0",
+            "conventional-changelog-angular": "1.5.0",
+            "conventional-commits-parser": "2.1.0",
+            "cosmiconfig": "3.1.0",
+            "find-up": "2.1.0",
+            "git-raw-commits": "1.3.0",
+            "lodash": "4.17.4",
+            "require-uncached": "1.0.3",
+            "resolve-from": "4.0.0",
+            "resolve-global": "0.1.0",
+            "semver": "5.4.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.4.0"
+          }
+        },
+        "conventional-commits-parser": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.0.tgz",
+          "integrity": "sha512-8MD05yN0Zb6aRsZnFX1ET+8rHWfWJk+my7ANCJZBU2mhz7TSB1fk2vZhkrwVy/PCllcTYAP/1T1NiWQ7Z01mKw==",
+          "dev": true,
+          "requires": {
+            "JSONStream": "1.3.1",
+            "is-text-path": "1.0.1",
+            "lodash": "4.17.4",
+            "meow": "3.7.0",
+            "split2": "2.1.1",
+            "through2": "2.0.3",
+            "trim-off-newlines": "1.0.1"
+          }
+        },
+        "cosmiconfig": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+          "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+          "dev": true,
+          "requires": {
+            "is-directory": "0.3.1",
+            "js-yaml": "3.10.0",
+            "parse-json": "3.0.0",
+            "require-from-string": "2.0.1"
+          }
+        },
+        "git-raw-commits": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.0.tgz",
+          "integrity": "sha1-C8hZbpDV/+c29/VUa9LRL3OrqsY=",
+          "dev": true,
+          "requires": {
+            "dargs": "4.1.0",
+            "lodash.template": "4.4.0",
+            "meow": "3.7.0",
+            "split2": "2.1.1",
+            "through2": "2.0.3"
+          }
+        },
+        "parse-json": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "require-from-string": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+          "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
       }
     },
     "@commitlint/config-angular": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-angular/-/config-angular-3.1.1.tgz",
-      "integrity": "sha1-VfIoOAPGpOAedV0JEu/511c1M2Y=",
-      "dev": true
-    },
-    "@commitlint/core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/core/-/core-3.2.0.tgz",
-      "integrity": "sha1-MXU+dy0JS3LKmKXwWP5WFeVMeac=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-angular/-/config-angular-5.1.1.tgz",
+      "integrity": "sha512-6tTIm/vIxetMsoARA3WLQVYpjr1JQxbshN+Ax1neIU0rz3weJEeSdG21n6nAPH1fBcsZ0kLALN7J4umFVuXTgw==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "chalk": "2.1.0",
-        "conventional-changelog-angular": "1.5.0",
-        "conventional-commits-parser": "1.3.0",
-        "find-up": "2.1.0",
-        "franc": "2.0.0",
-        "git-raw-commits": "1.2.0",
-        "import-from": "2.1.0",
-        "lodash": "4.17.4",
-        "mz": "2.7.0",
-        "path-exists": "3.0.0",
-        "pos": "0.4.2",
-        "rc": "1.2.1",
-        "resolve-from": "3.0.0",
-        "semver": "5.4.1"
+        "@commitlint/config-angular-type-enum": "5.1.1"
+      }
+    },
+    "@commitlint/config-angular-type-enum": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-angular-type-enum/-/config-angular-type-enum-5.1.1.tgz",
+      "integrity": "sha512-5DE9BRJHxPDtSNqz3C7QD5xBMQL8wII+r6EWSj8O888Ps66tVlHzwj4grF+fe4+wg1d03+n4eZE+4PaV6Ua1cQ==",
+      "dev": true
+    },
+    "@marionebl/sander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
+      "integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
       }
     },
     "@types/chai": {
@@ -144,10 +236,10 @@
         "color-convert": "1.9.0"
       }
     },
-    "any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+    "any-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+      "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
       "dev": true
     },
     "anymatch": {
@@ -644,6 +736,23 @@
         "os-homedir": "1.0.2"
       }
     },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+          "dev": true
+        }
+      }
+    },
     "callsites": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
@@ -1115,21 +1224,6 @@
         "modify-values": "1.0.0"
       }
     },
-    "conventional-commits-parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.3.0.tgz",
-      "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
-      "dev": true,
-      "requires": {
-        "JSONStream": "1.3.1",
-        "is-text-path": "1.0.1",
-        "lodash": "4.17.4",
-        "meow": "3.7.0",
-        "split2": "2.1.1",
-        "through2": "2.0.3",
-        "trim-off-newlines": "1.0.1"
-      }
-    },
     "convert-source-map": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
@@ -1149,19 +1243,26 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
-      "integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
+        "is-directory": "0.3.1",
         "js-yaml": "3.10.0",
-        "minimist": "1.2.0",
-        "object-assign": "4.1.1",
-        "os-homedir": "1.0.2",
-        "parse-json": "2.2.0",
-        "pinkie-promise": "2.0.1",
-        "require-from-string": "1.2.1"
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.1"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -1220,15 +1321,14 @@
       }
     },
     "cz-conventional-changelog": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-2.0.0.tgz",
-      "integrity": "sha1-Val5r9/pXnAkh50qD1kkYwFwtTM=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-2.1.0.tgz",
+      "integrity": "sha1-L0vHOQ4yROTfKT5ro1Hkx0Cnx2Q=",
       "dev": true,
       "requires": {
         "conventional-commit-types": "2.2.0",
         "lodash.map": "4.6.0",
         "longest": "1.0.1",
-        "pad-right": "0.2.2",
         "right-pad": "1.0.1",
         "word-wrap": "1.2.3"
       }
@@ -1304,12 +1404,6 @@
       "requires": {
         "type-detect": "4.0.3"
       }
-    },
-    "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1727,6 +1821,12 @@
         "merge": "1.2.0"
       }
     },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
+    },
     "find-root": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.0.0.tgz",
@@ -1805,15 +1905,6 @@
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
         "mime-types": "2.1.17"
-      }
-    },
-    "franc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/franc/-/franc-2.0.0.tgz",
-      "integrity": "sha1-2ZOe3tS0hqz0ufM1kf6OaeVGRhY=",
-      "dev": true,
-      "requires": {
-        "trigram-utils": "0.1.1"
       }
     },
     "from": {
@@ -2905,6 +2996,15 @@
         }
       }
     },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "requires": {
+        "ini": "1.3.4"
+      }
+    },
     "global-modules": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
@@ -3096,15 +3196,6 @@
       "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
       "dev": true
     },
-    "import-from": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
-      "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
-      "dev": true,
-      "requires": {
-        "resolve-from": "3.0.0"
-      }
-    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3253,6 +3344,12 @@
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -3317,6 +3414,23 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
+    },
+    "is-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "0.2.4"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+          "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+          "dev": true
+        }
+      }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -4564,48 +4678,78 @@
       }
     },
     "lint-staged": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-4.2.2.tgz",
-      "integrity": "sha512-29NaaMLV1vEKJsZQNSoskOQ4hBgVxNoS9+Jy0rKVlR9UXCpAqZbUxmPubc5B5PG29Eg/OxdwOQcfYMAFWrXjiA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.0.0.tgz",
+      "integrity": "sha512-ZUftK94S4vedpQG1LlA2tc2AuQXXBwc+1lB+j8SEfG5+p2dqu3Ug8iYQ8jdap+uLkhDw4OaJXqE+CZ/L+vfv+Q==",
       "dev": true,
       "requires": {
         "app-root-path": "2.0.1",
         "chalk": "2.1.0",
-        "cosmiconfig": "1.1.0",
+        "commander": "2.11.0",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "dedent": "0.7.0",
         "execa": "0.8.0",
+        "find-parent-dir": "0.3.0",
         "is-glob": "4.0.0",
         "jest-validate": "21.1.0",
-        "listr": "0.12.0",
+        "listr": "0.13.0",
         "lodash": "4.17.4",
         "log-symbols": "2.0.0",
         "minimatch": "3.0.4",
         "npm-which": "3.0.1",
         "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
         "staged-git-files": "0.0.4",
         "stringify-object": "3.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "dedent": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+          "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "listr": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
-      "integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+      "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "cli-truncate": "0.2.1",
         "figures": "1.7.0",
         "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
         "is-promise": "2.1.0",
         "is-stream": "1.1.0",
         "listr-silent-renderer": "1.1.1",
-        "listr-update-renderer": "0.2.0",
+        "listr-update-renderer": "0.4.0",
         "listr-verbose-renderer": "0.4.0",
         "log-symbols": "1.0.2",
         "log-update": "1.0.2",
         "ora": "0.2.3",
         "p-map": "1.2.0",
         "rxjs": "5.4.3",
-        "stream-to-observable": "0.1.0",
+        "stream-to-observable": "0.2.0",
         "strip-ansi": "3.0.1"
       },
       "dependencies": {
@@ -4652,9 +4796,9 @@
       "dev": true
     },
     "listr-update-renderer": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
-      "integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
@@ -5063,23 +5207,6 @@
       "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
       "dev": true
     },
-    "mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
-      "requires": {
-        "any-promise": "1.3.0",
-        "object-assign": "4.1.1",
-        "thenify-all": "1.6.0"
-      }
-    },
-    "n-gram": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/n-gram/-/n-gram-0.1.2.tgz",
-      "integrity": "sha1-ms7LD3l/v9IqCtiijZh4gKYwAqs=",
-      "dev": true
-    },
     "nan": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
@@ -5458,12 +5585,14 @@
         "camelcase": {
           "version": "1.2.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "center-align": {
           "version": "0.1.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "align-text": "0.1.4",
             "lazy-cache": "1.0.4"
@@ -5485,6 +5614,7 @@
           "version": "2.1.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "center-align": "0.1.3",
             "right-align": "0.1.3",
@@ -5494,7 +5624,8 @@
             "wordwrap": {
               "version": "0.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -6017,7 +6148,8 @@
         "lazy-cache": {
           "version": "1.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lcid": {
           "version": "1.0.0",
@@ -6479,6 +6611,7 @@
           "version": "0.1.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "align-text": "0.1.4"
           }
@@ -6665,7 +6798,8 @@
         "uglify-to-browserify": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
@@ -6692,7 +6826,8 @@
         "window-size": {
           "version": "0.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
@@ -7136,6 +7271,12 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -7209,12 +7350,6 @@
       "requires": {
         "find-up": "2.1.0"
       }
-    },
-    "pos": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/pos/-/pos-0.4.2.tgz",
-      "integrity": "sha1-IOnHf77tzDVoI86mPHWFys6Tvio=",
-      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -7328,18 +7463,6 @@
             "is-buffer": "1.1.5"
           }
         }
-      }
-    },
-    "rc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-      "dev": true,
-      "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.4",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
       }
     },
     "read-pkg": {
@@ -7501,9 +7624,9 @@
       "dev": true
     },
     "require-from-string": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
       "dev": true
     },
     "require-main-filename": {
@@ -7511,6 +7634,24 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+          "dev": true
+        }
+      }
     },
     "resolve": {
       "version": "1.4.0",
@@ -7531,11 +7672,14 @@
         "global-modules": "0.2.3"
       }
     },
-    "resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-      "dev": true
+    "resolve-global": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-0.1.0.tgz",
+      "integrity": "sha1-j7As/Vt9sgEY6IYxHxWvlb0V+9k=",
+      "dev": true,
+      "requires": {
+        "global-dirs": "0.1.1"
+      }
     },
     "restore-cursor": {
       "version": "1.0.1",
@@ -7830,10 +7974,13 @@
       }
     },
     "stream-to-observable": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
-      "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
-      "dev": true
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+      "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+      "dev": true,
+      "requires": {
+        "any-observable": "0.2.0"
+      }
     },
     "string-length": {
       "version": "2.0.0",
@@ -8006,24 +8153,6 @@
       "integrity": "sha1-dxVhsmAieDpF9bbC54rW596f4yI=",
       "dev": true
     },
-    "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
-      "dev": true,
-      "requires": {
-        "any-promise": "1.3.0"
-      }
-    },
-    "thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
-      "dev": true,
-      "requires": {
-        "thenify": "3.3.0"
-      }
-    },
     "throat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
@@ -8081,15 +8210,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
       "dev": true
-    },
-    "trigram-utils": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/trigram-utils/-/trigram-utils-0.1.1.tgz",
-      "integrity": "sha1-ffigksmJf8Lgnawi9CPigyMXYuc=",
-      "dev": true,
-      "requires": {
-        "n-gram": "0.1.2"
-      }
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -8335,9 +8455,9 @@
       }
     },
     "tslint-no-unused-expression-chai": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/tslint-no-unused-expression-chai/-/tslint-no-unused-expression-chai-0.0.2.tgz",
-      "integrity": "sha1-MsdpWQFURTRnicKWJJEVQ0ejo7E=",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tslint-no-unused-expression-chai/-/tslint-no-unused-expression-chai-0.0.3.tgz",
+      "integrity": "sha512-jKqhimj5gKl96ngeKxSVG1nOE7wmKRiHXD3kKpi+GG+5CmXJevD0ogsThZ8uSQCBIELFLVqXpZ43PpLniWu7jw==",
       "dev": true,
       "requires": {
         "tsutils": "2.8.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rx-sandbox",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Marble diagram DSL based test suite for RxJS 5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "cz-conventional-changelog": "2.1.0",
     "husky": "^0.14.3",
     "jest": "^21.0.1",
-    "lint-staged": "^5.0.0",
+    "lint-staged": "^6.0.0",
     "npm-run-all": "^4.0.2",
     "nyc": "^11.2.1",
     "prettier": "^1.5.3",

--- a/src/scheduler/TestScheduler.ts
+++ b/src/scheduler/TestScheduler.ts
@@ -109,7 +109,6 @@ class TestScheduler extends VirtualTimeScheduler {
       : parseObservableMarble(marbleValue, value, error, false, this.frameTimeFactor, this._maxFrame) as any;
     const subject = new HotObservable<T>(messages as Array<TestMessage<T | Array<TestMessage<T>>>>, this);
     this.hotObservables.push(subject);
-    subject.setup();
     return subject;
   }
 
@@ -148,6 +147,11 @@ class TestScheduler extends VirtualTimeScheduler {
   private flushUntil(toFrame: number = this.maxFrame): void {
     if (this.flushing) {
       return;
+    }
+
+    const { hotObservables } = this;
+    while (hotObservables.length > 0) {
+      hotObservables.shift()!.setup();
     }
 
     this.flushing = true;


### PR DESCRIPTION
There was race conditions in virtualtimescheduler, as rxSandbox eagerly setup hot observable subjects so when `getMessages` are called, first frames are flushed out before setting up the subscription. This PR defer hot observable setup when actual flush happens.