### PR TITLE
fix(getmarbletokenvalue): allow `undefined` as token value

### DIFF
--- a/spec/marbles/parseObservableMarble-spec.ts
+++ b/spec/marbles/parseObservableMarble-spec.ts
@@ -27,11 +27,11 @@ describe('parseObservableMarble', () => {
     expect(messages).to.deep.equal(expected);
   });
 
-  it('should correctly parse falsy timeframe value', () => {
+  it('should correctly parse falsy timeframe values', () => {
     const marble = '--a-b-c-d';
 
     const messages = parseObservableMarble(marble, { a: null, b: false, c: 0, d: undefined });
-    const expected = [next(2, null), next(4, false), next(6, 0), next(8, 'd')];
+    const expected = [next(2, null), next(4, false), next(6, 0), next(8, undefined)];
 
     expect(messages).to.deep.equal(expected);
   });

--- a/src/marbles/tokenParseReducer.ts
+++ b/src/marbles/tokenParseReducer.ts
@@ -1,6 +1,5 @@
 import { ColdObservable } from 'rxjs/internal/testing/ColdObservable';
-import { TestMessage } from '../message/TestMessage';
-import { complete, error as e, next } from '../message/TestMessage';
+import { complete, error as e, next, TestMessage } from '../message/TestMessage';
 import { ObservableMarbleToken } from './ObservableMarbleToken';
 import { SubscriptionMarbleToken } from './SubscriptionMarbleToken';
 
@@ -58,7 +57,7 @@ const getMarbleTokenValue = <T>(
   value: { [key: string]: T } | null,
   materializeInnerObservables: boolean
 ) => {
-  const customValue = value && typeof value[token] !== 'undefined' ? value[token] : token;
+  const customValue = value && token in value ? value[token] : token;
 
   return materializeInnerObservables && customValue instanceof ColdObservable ? customValue.messages : customValue;
 };


### PR DESCRIPTION
#47 allowed falsey types as token values but omitted `undefined`. This will allow `undefined` to be a valid comparison target, so:
```ts
const expected = sandbox.e('--a--', { a: undefined });
```
no longer treats the token `a` as the character literal `'a'`